### PR TITLE
wip: add socks5 support

### DIFF
--- a/expexp.yaml
+++ b/expexp.yaml
@@ -25,3 +25,15 @@ modules:
        port: 9115
        path: probe
 
+
+  myservice:
+    method: http
+    http:
+      ports:
+        - 8100-8120                  # myservice:8100 to myservice:8120
+        - 192.168.1.1:8100-8120:8300 # myservice:8300 to myservice:8320
+
+  myservice2:
+    method: http
+    http:
+      port: 8100                     # myservice:0 or myservice:8100

--- a/http.go
+++ b/http.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -39,7 +38,7 @@ func (c httpConfig) GatherWithContext(ctx context.Context, r *http.Request) prom
 
 		url := &url.URL{
 			Scheme:   c.Scheme,
-			Host:     net.JoinHostPort(c.Address, strconv.Itoa(c.Port)),
+			Host:     c.firstHostport(),
 			Path:     c.Path,
 			RawQuery: vs.Encode(),
 		}
@@ -99,7 +98,7 @@ func (c httpConfig) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				r.URL.RawQuery = vs.Encode()
 
 				r.URL.Scheme = c.Scheme
-				r.URL.Host = net.JoinHostPort(c.Address, strconv.Itoa(c.Port))
+				r.URL.Host = c.firstHostport()
 				r.URL.Path = c.Path
 
 			},

--- a/pkg/portmap/nat.go
+++ b/pkg/portmap/nat.go
@@ -1,0 +1,242 @@
+// Package nat is a convenience package for manipulation of strings describing network ports.
+package portmap
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+const (
+	// portSpecTemplate is the expected format for port specifications
+	portSpecTemplate = "ip:hostPort:containerPort"
+)
+
+// PortBinding represents a binding between a Host IP address and a Host Port
+type PortBinding struct {
+	// HostIP is the host IP Address
+	HostIP string `json:"HostIp"`
+	// HostPort is the host port number
+	HostPort string
+}
+
+// PortMap is a collection of PortBinding indexed by Port
+type PortMap map[Port][]PortBinding
+
+// PortSet is a collection of structs indexed by Port
+type PortSet map[Port]struct{}
+
+// Port is a string containing port number and protocol in the format "80/tcp"
+type Port string
+
+// NewPort creates a new instance of a Port given a protocol and port number or port range
+func NewPort(proto, port string) (Port, error) {
+	// Check for parsing issues on "port" now so we can avoid having
+	// to check it later on.
+
+	portStartInt, portEndInt, err := ParsePortRangeToInt(port)
+	if err != nil {
+		return "", err
+	}
+
+	if portStartInt == portEndInt {
+		return Port(fmt.Sprintf("%d/%s", portStartInt, proto)), nil
+	}
+	return Port(fmt.Sprintf("%d-%d/%s", portStartInt, portEndInt, proto)), nil
+}
+
+// ParsePort parses the port number string and returns an int
+func ParsePort(rawPort string) (int, error) {
+	if len(rawPort) == 0 {
+		return 0, nil
+	}
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	return int(port), nil
+}
+
+// ParsePortRangeToInt parses the port range string and returns start/end ints
+func ParsePortRangeToInt(rawPort string) (int, int, error) {
+	if len(rawPort) == 0 {
+		return 0, 0, nil
+	}
+	start, end, err := ParsePortRange(rawPort)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(start), int(end), nil
+}
+
+// Proto returns the protocol of a Port
+func (p Port) Proto() string {
+	proto, _ := SplitProtoPort(string(p))
+	return proto
+}
+
+// Port returns the port number of a Port
+func (p Port) Port() string {
+	_, port := SplitProtoPort(string(p))
+	return port
+}
+
+// Int returns the port number of a Port as an int
+func (p Port) Int() int {
+	portStr := p.Port()
+	// We don't need to check for an error because we're going to
+	// assume that any error would have been found, and reported, in NewPort()
+	port, _ := ParsePort(portStr)
+	return port
+}
+
+// Range returns the start/end port numbers of a Port range as ints
+func (p Port) Range() (int, int, error) {
+	return ParsePortRangeToInt(p.Port())
+}
+
+// SplitProtoPort splits a port in the format of proto/port
+func SplitProtoPort(rawPort string) (string, string) {
+	parts := strings.Split(rawPort, "/")
+	l := len(parts)
+	if len(rawPort) == 0 || l == 0 || len(parts[0]) == 0 {
+		return "", ""
+	}
+	if l == 1 {
+		return "tcp", rawPort
+	}
+	if len(parts[1]) == 0 {
+		return "tcp", parts[0]
+	}
+	return parts[1], parts[0]
+}
+
+func validateProto(proto string) bool {
+	for _, availableProto := range []string{"tcp", "udp"} {
+		if availableProto == proto {
+			return true
+		}
+	}
+	return false
+}
+
+// ParsePortSpecs receives port specs in the format of ip:public:private/proto and parses
+// these in to the internal types
+func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, error) {
+	var (
+		exposedPorts = make(map[Port]struct{}, len(ports))
+		bindings     = make(map[Port][]PortBinding)
+	)
+	for _, rawPort := range ports {
+		portMappings, err := ParsePortSpec(rawPort)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, portMapping := range portMappings {
+			port := portMapping.Port
+			if _, exists := exposedPorts[port]; !exists {
+				exposedPorts[port] = struct{}{}
+			}
+			bslice, exists := bindings[port]
+			if !exists {
+				bslice = []PortBinding{}
+			}
+			bindings[port] = append(bslice, portMapping.Binding)
+		}
+	}
+	return exposedPorts, bindings, nil
+}
+
+// PortMapping is a data object mapping a Port to a PortBinding
+type PortMapping struct {
+	Port    Port
+	Binding PortBinding
+}
+
+func splitParts(rawport string) (string, string, string) {
+	parts := strings.Split(rawport, ":")
+	n := len(parts)
+	containerport := parts[n-1]
+
+	switch n {
+	case 1:
+		return "", "", containerport
+	case 2:
+		return "", parts[0], containerport
+	case 3:
+		return parts[0], parts[1], containerport
+	default:
+		return strings.Join(parts[:n-2], ":"), parts[n-2], containerport
+	}
+}
+
+// ParsePortSpec parses a port specification string into a slice of PortMappings
+func ParsePortSpec(rawPort string) ([]PortMapping, error) {
+	var proto string
+	rawIP, hostPort, containerPort := splitParts(rawPort)
+	proto, containerPort = SplitProtoPort(containerPort)
+
+	// Strip [] from IPV6 addresses
+	ip, _, err := net.SplitHostPort(rawIP + ":")
+	if err != nil {
+		return nil, fmt.Errorf("Invalid ip address %v: %s", rawIP, err)
+	}
+	if ip != "" && net.ParseIP(ip) == nil {
+		return nil, fmt.Errorf("Invalid ip address: %s", ip)
+	}
+	if containerPort == "" {
+		return nil, fmt.Errorf("No port specified: %s<empty>", rawPort)
+	}
+
+	startPort, endPort, err := ParsePortRange(containerPort)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid containerPort: %s", containerPort)
+	}
+
+	var startHostPort, endHostPort uint64 = 0, 0
+	if len(hostPort) > 0 {
+		startHostPort, endHostPort, err = ParsePortRange(hostPort)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid hostPort: %s", hostPort)
+		}
+	}
+
+	if hostPort != "" && (endPort-startPort) != (endHostPort-startHostPort) {
+		// Allow host port range iff containerPort is not a range.
+		// In this case, use the host port range as the dynamic
+		// host port range to allocate into.
+		if endPort != startPort {
+			return nil, fmt.Errorf("Invalid ranges specified for container and host Ports: %s and %s", containerPort, hostPort)
+		}
+	}
+
+	if !validateProto(strings.ToLower(proto)) {
+		return nil, fmt.Errorf("Invalid proto: %s", proto)
+	}
+
+	ports := []PortMapping{}
+	for i := uint64(0); i <= (endPort - startPort); i++ {
+		containerPort = strconv.FormatUint(startPort+i, 10)
+		if len(hostPort) > 0 {
+			hostPort = strconv.FormatUint(startHostPort+i, 10)
+		}
+		// Set hostPort to a range only if there is a single container port
+		// and a dynamic host port.
+		if startPort == endPort && startHostPort != endHostPort {
+			hostPort = fmt.Sprintf("%s-%s", hostPort, strconv.FormatUint(endHostPort, 10))
+		}
+		port, err := NewPort(strings.ToLower(proto), containerPort)
+		if err != nil {
+			return nil, err
+		}
+
+		binding := PortBinding{
+			HostIP:   ip,
+			HostPort: hostPort,
+		}
+		ports = append(ports, PortMapping{Port: port, Binding: binding})
+	}
+	return ports, nil
+}

--- a/pkg/portmap/nat_test.go
+++ b/pkg/portmap/nat_test.go
@@ -1,0 +1,583 @@
+package portmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePort(t *testing.T) {
+	var (
+		p   int
+		err error
+	)
+
+	p, err = ParsePort("1234")
+
+	if err != nil || p != 1234 {
+		t.Fatal("Parsing '1234' did not succeed")
+	}
+
+	// FIXME currently this is a valid port. I don't think it should be.
+	// I'm leaving this test commented out until we make a decision.
+	// - erikh
+
+	/*
+		p, err = ParsePort("0123")
+
+		if err != nil {
+		    t.Fatal("Successfully parsed port '0123' to '123'")
+		}
+	*/
+
+	p, err = ParsePort("asdf")
+
+	if err == nil || p != 0 {
+		t.Fatal("Parsing port 'asdf' succeeded")
+	}
+
+	p, err = ParsePort("1asdf")
+
+	if err == nil || p != 0 {
+		t.Fatal("Parsing port '1asdf' succeeded")
+	}
+}
+
+func TestParsePortRangeToInt(t *testing.T) {
+	var (
+		begin int
+		end   int
+		err   error
+	)
+
+	type TestRange struct {
+		Range string
+		Begin int
+		End   int
+	}
+	validRanges := []TestRange{
+		{"1234", 1234, 1234},
+		{"1234-1234", 1234, 1234},
+		{"1234-1235", 1234, 1235},
+		{"8000-9000", 8000, 9000},
+		{"0", 0, 0},
+		{"0-0", 0, 0},
+	}
+
+	for _, r := range validRanges {
+		begin, end, err = ParsePortRangeToInt(r.Range)
+
+		if err != nil || begin != r.Begin {
+			t.Fatalf("Parsing port range '%s' did not succeed. Expected begin %d, got %d", r.Range, r.Begin, begin)
+		}
+		if err != nil || end != r.End {
+			t.Fatalf("Parsing port range '%s' did not succeed. Expected end %d, got %d", r.Range, r.End, end)
+		}
+	}
+
+	invalidRanges := []string{
+		"asdf",
+		"1asdf",
+		"9000-8000",
+		"9000-",
+		"-8000",
+		"-8000-",
+	}
+
+	for _, r := range invalidRanges {
+		begin, end, err = ParsePortRangeToInt(r)
+
+		if err == nil || begin != 0 || end != 0 {
+			t.Fatalf("Parsing port range '%s' succeeded", r)
+		}
+	}
+}
+
+func TestPort(t *testing.T) {
+	p, err := NewPort("tcp", "1234")
+
+	if err != nil {
+		t.Fatalf("tcp, 1234 had a parsing issue: %v", err)
+	}
+
+	if string(p) != "1234/tcp" {
+		t.Fatal("tcp, 1234 did not result in the string 1234/tcp")
+	}
+
+	if p.Proto() != "tcp" {
+		t.Fatal("protocol was not tcp")
+	}
+
+	if p.Port() != "1234" {
+		t.Fatal("port string value was not 1234")
+	}
+
+	if p.Int() != 1234 {
+		t.Fatal("port int value was not 1234")
+	}
+
+	p, err = NewPort("tcp", "asd1234")
+	if err == nil {
+		t.Fatal("tcp, asd1234 was supposed to fail")
+	}
+
+	p, err = NewPort("tcp", "1234-1230")
+	if err == nil {
+		t.Fatal("tcp, 1234-1230 was supposed to fail")
+	}
+
+	p, err = NewPort("tcp", "1234-1242")
+	if err != nil {
+		t.Fatalf("tcp, 1234-1242 had a parsing issue: %v", err)
+	}
+
+	if string(p) != "1234-1242/tcp" {
+		t.Fatal("tcp, 1234-1242 did not result in the string 1234-1242/tcp")
+	}
+}
+
+func TestSplitProtoPort(t *testing.T) {
+	var (
+		proto string
+		port  string
+	)
+
+	proto, port = SplitProtoPort("1234/tcp")
+
+	if proto != "tcp" || port != "1234" {
+		t.Fatal("Could not split 1234/tcp properly")
+	}
+
+	proto, port = SplitProtoPort("")
+
+	if proto != "" || port != "" {
+		t.Fatal("parsing an empty string yielded surprising results", proto, port)
+	}
+
+	proto, port = SplitProtoPort("1234")
+
+	if proto != "tcp" || port != "1234" {
+		t.Fatal("tcp is not the default protocol for portspec '1234'", proto, port)
+	}
+
+	proto, port = SplitProtoPort("1234/")
+
+	if proto != "tcp" || port != "1234" {
+		t.Fatal("parsing '1234/' yielded:" + port + "/" + proto)
+	}
+
+	proto, port = SplitProtoPort("/tcp")
+
+	if proto != "" || port != "" {
+		t.Fatal("parsing '/tcp' yielded:" + port + "/" + proto)
+	}
+}
+
+func TestParsePortSpecFull(t *testing.T) {
+	portMappings, err := ParsePortSpec("0.0.0.0:1234-1235:3333-3334/tcp")
+	assert.Nil(t, err)
+
+	expected := []PortMapping{
+		{
+			Port: "3333/tcp",
+			Binding: PortBinding{
+				HostIP:   "0.0.0.0",
+				HostPort: "1234",
+			},
+		},
+		{
+			Port: "3334/tcp",
+			Binding: PortBinding{
+				HostIP:   "0.0.0.0",
+				HostPort: "1235",
+			},
+		},
+	}
+
+	assert.Equal(t, expected, portMappings)
+}
+
+func TestPartPortSpecIPV6(t *testing.T) {
+	portMappings, err := ParsePortSpec("[2001:4860:0:2001::68]::333")
+	assert.Nil(t, err)
+
+	expected := []PortMapping{
+		{
+			Port: "333/tcp",
+			Binding: PortBinding{
+				HostIP:   "2001:4860:0:2001::68",
+				HostPort: "",
+			},
+		},
+	}
+	assert.Equal(t, expected, portMappings)
+}
+
+func TestPartPortSpecIPV6WithHostPort(t *testing.T) {
+	portMappings, err := ParsePortSpec("[::1]:80:80")
+	assert.Nil(t, err)
+
+	expected := []PortMapping{
+		{
+			Port: "80/tcp",
+			Binding: PortBinding{
+				HostIP:   "::1",
+				HostPort: "80",
+			},
+		},
+	}
+	assert.Equal(t, expected, portMappings)
+}
+
+func TestParsePortSpecs(t *testing.T) {
+	var (
+		portMap    map[Port]struct{}
+		bindingMap map[Port][]PortBinding
+		err        error
+	)
+
+	portMap, bindingMap, err = ParsePortSpecs([]string{"1234/tcp", "2345/udp"})
+
+	if err != nil {
+		t.Fatalf("Error while processing ParsePortSpecs: %s", err)
+	}
+
+	if _, ok := portMap[Port("1234/tcp")]; !ok {
+		t.Fatal("1234/tcp was not parsed properly")
+	}
+
+	if _, ok := portMap[Port("2345/udp")]; !ok {
+		t.Fatal("2345/udp was not parsed properly")
+	}
+
+	for portspec, bindings := range bindingMap {
+		if len(bindings) != 1 {
+			t.Fatalf("%s should have exactly one binding", portspec)
+		}
+
+		if bindings[0].HostIP != "" {
+			t.Fatalf("HostIP should not be set for %s", portspec)
+		}
+
+		if bindings[0].HostPort != "" {
+			t.Fatalf("HostPort should not be set for %s", portspec)
+		}
+	}
+
+	portMap, bindingMap, err = ParsePortSpecs([]string{"1234:1234/tcp", "2345:2345/udp"})
+
+	if err != nil {
+		t.Fatalf("Error while processing ParsePortSpecs: %s", err)
+	}
+
+	if _, ok := portMap[Port("1234/tcp")]; !ok {
+		t.Fatal("1234/tcp was not parsed properly")
+	}
+
+	if _, ok := portMap[Port("2345/udp")]; !ok {
+		t.Fatal("2345/udp was not parsed properly")
+	}
+
+	for portspec, bindings := range bindingMap {
+		_, port := SplitProtoPort(string(portspec))
+
+		if len(bindings) != 1 {
+			t.Fatalf("%s should have exactly one binding", portspec)
+		}
+
+		if bindings[0].HostIP != "" {
+			t.Fatalf("HostIP should not be set for %s", portspec)
+		}
+
+		if bindings[0].HostPort != port {
+			t.Fatalf("HostPort should be %s for %s", port, portspec)
+		}
+	}
+
+	portMap, bindingMap, err = ParsePortSpecs([]string{"0.0.0.0:1234:1234/tcp", "0.0.0.0:2345:2345/udp"})
+
+	if err != nil {
+		t.Fatalf("Error while processing ParsePortSpecs: %s", err)
+	}
+
+	if _, ok := portMap[Port("1234/tcp")]; !ok {
+		t.Fatal("1234/tcp was not parsed properly")
+	}
+
+	if _, ok := portMap[Port("2345/udp")]; !ok {
+		t.Fatal("2345/udp was not parsed properly")
+	}
+
+	for portspec, bindings := range bindingMap {
+		_, port := SplitProtoPort(string(portspec))
+
+		if len(bindings) != 1 {
+			t.Fatalf("%s should have exactly one binding", portspec)
+		}
+
+		if bindings[0].HostIP != "0.0.0.0" {
+			t.Fatalf("HostIP is not 0.0.0.0 for %s", portspec)
+		}
+
+		if bindings[0].HostPort != port {
+			t.Fatalf("HostPort should be %s for %s", port, portspec)
+		}
+	}
+
+	_, _, err = ParsePortSpecs([]string{"localhost:1234:1234/tcp"})
+
+	if err == nil {
+		t.Fatal("Received no error while trying to parse a hostname instead of ip")
+	}
+}
+
+func TestParsePortSpecsWithRange(t *testing.T) {
+	var (
+		portMap    map[Port]struct{}
+		bindingMap map[Port][]PortBinding
+		err        error
+	)
+
+	portMap, bindingMap, err = ParsePortSpecs([]string{"1234-1236/tcp", "2345-2347/udp"})
+
+	if err != nil {
+		t.Fatalf("Error while processing ParsePortSpecs: %s", err)
+	}
+
+	if _, ok := portMap[Port("1235/tcp")]; !ok {
+		t.Fatal("1234/tcp was not parsed properly")
+	}
+
+	if _, ok := portMap[Port("2346/udp")]; !ok {
+		t.Fatal("2345/udp was not parsed properly")
+	}
+
+	for portspec, bindings := range bindingMap {
+		if len(bindings) != 1 {
+			t.Fatalf("%s should have exactly one binding", portspec)
+		}
+
+		if bindings[0].HostIP != "" {
+			t.Fatalf("HostIP should not be set for %s", portspec)
+		}
+
+		if bindings[0].HostPort != "" {
+			t.Fatalf("HostPort should not be set for %s", portspec)
+		}
+	}
+
+	portMap, bindingMap, err = ParsePortSpecs([]string{"1234-1236:1234-1236/tcp", "2345-2347:2345-2347/udp"})
+
+	if err != nil {
+		t.Fatalf("Error while processing ParsePortSpecs: %s", err)
+	}
+
+	if _, ok := portMap[Port("1235/tcp")]; !ok {
+		t.Fatal("1234/tcp was not parsed properly")
+	}
+
+	if _, ok := portMap[Port("2346/udp")]; !ok {
+		t.Fatal("2345/udp was not parsed properly")
+	}
+
+	for portspec, bindings := range bindingMap {
+		_, port := SplitProtoPort(string(portspec))
+		if len(bindings) != 1 {
+			t.Fatalf("%s should have exactly one binding", portspec)
+		}
+
+		if bindings[0].HostIP != "" {
+			t.Fatalf("HostIP should not be set for %s", portspec)
+		}
+
+		if bindings[0].HostPort != port {
+			t.Fatalf("HostPort should be %s for %s", port, portspec)
+		}
+	}
+
+	portMap, bindingMap, err = ParsePortSpecs([]string{"0.0.0.0:1234-1236:1234-1236/tcp", "0.0.0.0:2345-2347:2345-2347/udp"})
+
+	if err != nil {
+		t.Fatalf("Error while processing ParsePortSpecs: %s", err)
+	}
+
+	if _, ok := portMap[Port("1235/tcp")]; !ok {
+		t.Fatal("1234/tcp was not parsed properly")
+	}
+
+	if _, ok := portMap[Port("2346/udp")]; !ok {
+		t.Fatal("2345/udp was not parsed properly")
+	}
+
+	for portspec, bindings := range bindingMap {
+		_, port := SplitProtoPort(string(portspec))
+		if len(bindings) != 1 || bindings[0].HostIP != "0.0.0.0" || bindings[0].HostPort != port {
+			t.Fatalf("Expect single binding to port %s but found %s", port, bindings)
+		}
+	}
+
+	_, _, err = ParsePortSpecs([]string{"localhost:1234-1236:1234-1236/tcp"})
+
+	if err == nil {
+		t.Fatal("Received no error while trying to parse a hostname instead of ip")
+	}
+}
+
+func TestParseNetworkOptsPrivateOnly(t *testing.T) {
+	ports, bindings, err := ParsePortSpecs([]string{"192.168.1.100::80"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 1 {
+		t.Logf("Expected 1 got %d", len(ports))
+		t.FailNow()
+	}
+	if len(bindings) != 1 {
+		t.Logf("Expected 1 got %d", len(bindings))
+		t.FailNow()
+	}
+	for k := range ports {
+		if k.Proto() != "tcp" {
+			t.Logf("Expected tcp got %s", k.Proto())
+			t.Fail()
+		}
+		if k.Port() != "80" {
+			t.Logf("Expected 80 got %s", k.Port())
+			t.Fail()
+		}
+		b, exists := bindings[k]
+		if !exists {
+			t.Log("Binding does not exist")
+			t.FailNow()
+		}
+		if len(b) != 1 {
+			t.Logf("Expected 1 got %d", len(b))
+			t.FailNow()
+		}
+		s := b[0]
+		if s.HostPort != "" {
+			t.Logf("Expected \"\" got %s", s.HostPort)
+			t.Fail()
+		}
+		if s.HostIP != "192.168.1.100" {
+			t.Fail()
+		}
+	}
+}
+
+func TestParseNetworkOptsPublic(t *testing.T) {
+	ports, bindings, err := ParsePortSpecs([]string{"192.168.1.100:8080:80"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 1 {
+		t.Logf("Expected 1 got %d", len(ports))
+		t.FailNow()
+	}
+	if len(bindings) != 1 {
+		t.Logf("Expected 1 got %d", len(bindings))
+		t.FailNow()
+	}
+	for k := range ports {
+		if k.Proto() != "tcp" {
+			t.Logf("Expected tcp got %s", k.Proto())
+			t.Fail()
+		}
+		if k.Port() != "80" {
+			t.Logf("Expected 80 got %s", k.Port())
+			t.Fail()
+		}
+		b, exists := bindings[k]
+		if !exists {
+			t.Log("Binding does not exist")
+			t.FailNow()
+		}
+		if len(b) != 1 {
+			t.Logf("Expected 1 got %d", len(b))
+			t.FailNow()
+		}
+		s := b[0]
+		if s.HostPort != "8080" {
+			t.Logf("Expected 8080 got %s", s.HostPort)
+			t.Fail()
+		}
+		if s.HostIP != "192.168.1.100" {
+			t.Fail()
+		}
+	}
+}
+
+func TestParseNetworkOptsPublicNoPort(t *testing.T) {
+	ports, bindings, err := ParsePortSpecs([]string{"192.168.1.100"})
+
+	if err == nil {
+		t.Logf("Expected error Invalid containerPort")
+		t.Fail()
+	}
+	if ports != nil {
+		t.Logf("Expected nil got %s", ports)
+		t.Fail()
+	}
+	if bindings != nil {
+		t.Logf("Expected nil got %s", bindings)
+		t.Fail()
+	}
+}
+
+func TestParseNetworkOptsNegativePorts(t *testing.T) {
+	ports, bindings, err := ParsePortSpecs([]string{"192.168.1.100:-1:-1"})
+
+	if err == nil {
+		t.Fail()
+	}
+	if len(ports) != 0 {
+		t.Logf("Expected nil got %d", len(ports))
+		t.Fail()
+	}
+	if len(bindings) != 0 {
+		t.Logf("Expected 0 got %d", len(bindings))
+		t.Fail()
+	}
+}
+
+func TestParseNetworkOptsUdp(t *testing.T) {
+	ports, bindings, err := ParsePortSpecs([]string{"192.168.1.100::6000/udp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 1 {
+		t.Logf("Expected 1 got %d", len(ports))
+		t.FailNow()
+	}
+	if len(bindings) != 1 {
+		t.Logf("Expected 1 got %d", len(bindings))
+		t.FailNow()
+	}
+	for k := range ports {
+		if k.Proto() != "udp" {
+			t.Logf("Expected udp got %s", k.Proto())
+			t.Fail()
+		}
+		if k.Port() != "6000" {
+			t.Logf("Expected 6000 got %s", k.Port())
+			t.Fail()
+		}
+		b, exists := bindings[k]
+		if !exists {
+			t.Log("Binding does not exist")
+			t.FailNow()
+		}
+		if len(b) != 1 {
+			t.Logf("Expected 1 got %d", len(b))
+			t.FailNow()
+		}
+		s := b[0]
+		if s.HostPort != "" {
+			t.Logf("Expected \"\" got %s", s.HostPort)
+			t.Fail()
+		}
+		if s.HostIP != "192.168.1.100" {
+			t.Fail()
+		}
+	}
+}

--- a/pkg/portmap/parse.go
+++ b/pkg/portmap/parse.go
@@ -1,0 +1,57 @@
+package portmap
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PartParser parses and validates the specified string (data) using the specified template
+// e.g. ip:public:private -> 192.168.0.1:80:8000
+// DEPRECATED: do not use, this function may be removed in a future version
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse. %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+// ParsePortRange parses and validates the specified string as a port-range (8000-9000)
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}

--- a/pkg/portmap/parse_test.go
+++ b/pkg/portmap/parse_test.go
@@ -1,0 +1,54 @@
+package portmap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePortRange(t *testing.T) {
+	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
+		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
+	}
+}
+
+func TestParsePortRangeEmpty(t *testing.T) {
+	if _, _, err := ParsePortRange(""); err == nil || err.Error() != "Empty string specified for ports." {
+		t.Fatalf("Expected error 'Empty string specified for ports.', got %v", err)
+	}
+}
+
+func TestParsePortRangeWithNoRange(t *testing.T) {
+	start, end, err := ParsePortRange("8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start != 8080 || end != 8080 {
+		t.Fatalf("Expected start and end to be the same and equal to 8080, but were %v and %v", start, end)
+	}
+}
+
+func TestParsePortRangeIncorrectRange(t *testing.T) {
+	if _, _, err := ParsePortRange("9000-8080"); err == nil || !strings.Contains(err.Error(), "Invalid range specified for the Port") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectEndRange(t *testing.T) {
+	if _, _, err := ParsePortRange("8000-a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("8000-30a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectStartRange(t *testing.T) {
+	if _, _, err := ParsePortRange("a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("30a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}

--- a/pkg/portmap/sort.go
+++ b/pkg/portmap/sort.go
@@ -1,0 +1,96 @@
+package portmap
+
+import (
+	"sort"
+	"strings"
+)
+
+type portSorter struct {
+	ports []Port
+	by    func(i, j Port) bool
+}
+
+func (s *portSorter) Len() int {
+	return len(s.ports)
+}
+
+func (s *portSorter) Swap(i, j int) {
+	s.ports[i], s.ports[j] = s.ports[j], s.ports[i]
+}
+
+func (s *portSorter) Less(i, j int) bool {
+	ip := s.ports[i]
+	jp := s.ports[j]
+
+	return s.by(ip, jp)
+}
+
+// Sort sorts a list of ports using the provided predicate
+// This function should compare `i` and `j`, returning true if `i` is
+// considered to be less than `j`
+func Sort(ports []Port, predicate func(i, j Port) bool) {
+	s := &portSorter{ports, predicate}
+	sort.Sort(s)
+}
+
+type portMapEntry struct {
+	port    Port
+	binding PortBinding
+}
+
+type portMapSorter []portMapEntry
+
+func (s portMapSorter) Len() int      { return len(s) }
+func (s portMapSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// sort the port so that the order is:
+// 1. port with larger specified bindings
+// 2. larger port
+// 3. port with tcp protocol
+func (s portMapSorter) Less(i, j int) bool {
+	pi, pj := s[i].port, s[j].port
+	hpi, hpj := toInt(s[i].binding.HostPort), toInt(s[j].binding.HostPort)
+	return hpi > hpj || pi.Int() > pj.Int() || (pi.Int() == pj.Int() && strings.ToLower(pi.Proto()) == "tcp")
+}
+
+// SortPortMap sorts the list of ports and their respected mapping. The ports
+// will explicit HostPort will be placed first.
+func SortPortMap(ports []Port, bindings PortMap) {
+	s := portMapSorter{}
+	for _, p := range ports {
+		if binding, ok := bindings[p]; ok {
+			for _, b := range binding {
+				s = append(s, portMapEntry{port: p, binding: b})
+			}
+			bindings[p] = []PortBinding{}
+		} else {
+			s = append(s, portMapEntry{port: p})
+		}
+	}
+
+	sort.Sort(s)
+	var (
+		i  int
+		pm = make(map[Port]struct{})
+	)
+	// reorder ports
+	for _, entry := range s {
+		if _, ok := pm[entry.port]; !ok {
+			ports[i] = entry.port
+			pm[entry.port] = struct{}{}
+			i++
+		}
+		// reorder bindings for this port
+		if _, ok := bindings[entry.port]; ok {
+			bindings[entry.port] = append(bindings[entry.port], entry.binding)
+		}
+	}
+}
+
+func toInt(s string) uint64 {
+	i, _, err := ParsePortRange(s)
+	if err != nil {
+		i = 0
+	}
+	return i
+}

--- a/pkg/portmap/sort_test.go
+++ b/pkg/portmap/sort_test.go
@@ -1,0 +1,85 @@
+package portmap
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestSortUniquePorts(t *testing.T) {
+	ports := []Port{
+		Port("6379/tcp"),
+		Port("22/tcp"),
+	}
+
+	Sort(ports, func(ip, jp Port) bool {
+		return ip.Int() < jp.Int() || (ip.Int() == jp.Int() && ip.Proto() == "tcp")
+	})
+
+	first := ports[0]
+	if fmt.Sprint(first) != "22/tcp" {
+		t.Log(fmt.Sprint(first))
+		t.Fail()
+	}
+}
+
+func TestSortSamePortWithDifferentProto(t *testing.T) {
+	ports := []Port{
+		Port("8888/tcp"),
+		Port("8888/udp"),
+		Port("6379/tcp"),
+		Port("6379/udp"),
+	}
+
+	Sort(ports, func(ip, jp Port) bool {
+		return ip.Int() < jp.Int() || (ip.Int() == jp.Int() && ip.Proto() == "tcp")
+	})
+
+	first := ports[0]
+	if fmt.Sprint(first) != "6379/tcp" {
+		t.Fail()
+	}
+}
+
+func TestSortPortMap(t *testing.T) {
+	ports := []Port{
+		Port("22/tcp"),
+		Port("22/udp"),
+		Port("8000/tcp"),
+		Port("6379/tcp"),
+		Port("9999/tcp"),
+	}
+
+	portMap := PortMap{
+		Port("22/tcp"): []PortBinding{
+			{},
+		},
+		Port("8000/tcp"): []PortBinding{
+			{},
+		},
+		Port("6379/tcp"): []PortBinding{
+			{},
+			{HostIP: "0.0.0.0", HostPort: "32749"},
+		},
+		Port("9999/tcp"): []PortBinding{
+			{HostIP: "0.0.0.0", HostPort: "40000"},
+		},
+	}
+
+	SortPortMap(ports, portMap)
+	if !reflect.DeepEqual(ports, []Port{
+		Port("9999/tcp"),
+		Port("6379/tcp"),
+		Port("8000/tcp"),
+		Port("22/tcp"),
+		Port("22/udp"),
+	}) {
+		t.Errorf("failed to prioritize port with explicit mappings, got %v", ports)
+	}
+	if pm := portMap[Port("6379/tcp")]; !reflect.DeepEqual(pm, []PortBinding{
+		{HostIP: "0.0.0.0", HostPort: "32749"},
+		{},
+	}) {
+		t.Errorf("failed to prioritize bindings with explicit mappings, got %v", pm)
+	}
+}

--- a/pkg/socks5/.gitignore
+++ b/pkg/socks5/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/pkg/socks5/.travis.yml
+++ b/pkg/socks5/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+  - 1.1
+  - tip

--- a/pkg/socks5/LICENSE
+++ b/pkg/socks5/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Armon Dadgar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pkg/socks5/README.md
+++ b/pkg/socks5/README.md
@@ -1,0 +1,45 @@
+go-socks5 [![Build Status](https://travis-ci.org/armon/go-socks5.png)](https://travis-ci.org/armon/go-socks5)
+=========
+
+Provides the `socks5` package that implements a [SOCKS5 server](http://en.wikipedia.org/wiki/SOCKS).
+SOCKS (Secure Sockets) is used to route traffic between a client and server through
+an intermediate proxy layer. This can be used to bypass firewalls or NATs.
+
+Feature
+=======
+
+The package has the following features:
+* "No Auth" mode
+* User/Password authentication
+* Support for the CONNECT command
+* Rules to do granular filtering of commands
+* Custom DNS resolution
+* Unit tests
+
+TODO
+====
+
+The package still needs the following:
+* Support for the BIND command
+* Support for the ASSOCIATE command
+
+
+Example
+=======
+
+Below is a simple example of usage
+
+```go
+// Create a SOCKS5 server
+conf := &socks5.Config{}
+server, err := socks5.New(conf)
+if err != nil {
+  panic(err)
+}
+
+// Create SOCKS5 proxy on localhost port 8000
+if err := server.ListenAndServe("tcp", "127.0.0.1:8000"); err != nil {
+  panic(err)
+}
+```
+

--- a/pkg/socks5/auth.go
+++ b/pkg/socks5/auth.go
@@ -1,0 +1,151 @@
+package socks5
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	NoAuth          = uint8(0)
+	noAcceptable    = uint8(255)
+	UserPassAuth    = uint8(2)
+	userAuthVersion = uint8(1)
+	authSuccess     = uint8(0)
+	authFailure     = uint8(1)
+)
+
+var (
+	UserAuthFailed  = fmt.Errorf("User authentication failed")
+	NoSupportedAuth = fmt.Errorf("No supported authentication mechanism")
+)
+
+// A Request encapsulates authentication state provided
+// during negotiation
+type AuthContext struct {
+	// Provided auth method
+	Method uint8
+	// Payload provided during negotiation.
+	// Keys depend on the used auth method.
+	// For UserPassauth contains Username
+	Payload map[string]string
+}
+
+type Authenticator interface {
+	Authenticate(reader io.Reader, writer io.Writer) (*AuthContext, error)
+	GetCode() uint8
+}
+
+// NoAuthAuthenticator is used to handle the "No Authentication" mode
+type NoAuthAuthenticator struct{}
+
+func (a NoAuthAuthenticator) GetCode() uint8 {
+	return NoAuth
+}
+
+func (a NoAuthAuthenticator) Authenticate(reader io.Reader, writer io.Writer) (*AuthContext, error) {
+	_, err := writer.Write([]byte{socks5Version, NoAuth})
+	return &AuthContext{NoAuth, nil}, err
+}
+
+// UserPassAuthenticator is used to handle username/password based
+// authentication
+type UserPassAuthenticator struct {
+	Credentials CredentialStore
+}
+
+func (a UserPassAuthenticator) GetCode() uint8 {
+	return UserPassAuth
+}
+
+func (a UserPassAuthenticator) Authenticate(reader io.Reader, writer io.Writer) (*AuthContext, error) {
+	// Tell the client to use user/pass auth
+	if _, err := writer.Write([]byte{socks5Version, UserPassAuth}); err != nil {
+		return nil, err
+	}
+
+	// Get the version and username length
+	header := []byte{0, 0}
+	if _, err := io.ReadAtLeast(reader, header, 2); err != nil {
+		return nil, err
+	}
+
+	// Ensure we are compatible
+	if header[0] != userAuthVersion {
+		return nil, fmt.Errorf("Unsupported auth version: %v", header[0])
+	}
+
+	// Get the user name
+	userLen := int(header[1])
+	user := make([]byte, userLen)
+	if _, err := io.ReadAtLeast(reader, user, userLen); err != nil {
+		return nil, err
+	}
+
+	// Get the password length
+	if _, err := reader.Read(header[:1]); err != nil {
+		return nil, err
+	}
+
+	// Get the password
+	passLen := int(header[0])
+	pass := make([]byte, passLen)
+	if _, err := io.ReadAtLeast(reader, pass, passLen); err != nil {
+		return nil, err
+	}
+
+	// Verify the password
+	if a.Credentials.Valid(string(user), string(pass)) {
+		if _, err := writer.Write([]byte{userAuthVersion, authSuccess}); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := writer.Write([]byte{userAuthVersion, authFailure}); err != nil {
+			return nil, err
+		}
+		return nil, UserAuthFailed
+	}
+
+	// Done
+	return &AuthContext{UserPassAuth, map[string]string{"Username": string(user)}}, nil
+}
+
+// authenticate is used to handle connection authentication
+func (s *Server) authenticate(conn io.Writer, bufConn io.Reader) (*AuthContext, error) {
+	// Get the methods
+	methods, err := readMethods(bufConn)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get auth methods: %v", err)
+	}
+
+	// Select a usable method
+	for _, method := range methods {
+		cator, found := s.authMethods[method]
+		if found {
+			return cator.Authenticate(bufConn, conn)
+		}
+	}
+
+	// No usable method found
+	return nil, noAcceptableAuth(conn)
+}
+
+// noAcceptableAuth is used to handle when we have no eligible
+// authentication mechanism
+func noAcceptableAuth(conn io.Writer) error {
+	conn.Write([]byte{socks5Version, noAcceptable})
+	return NoSupportedAuth
+}
+
+// readMethods is used to read the number of methods
+// and proceeding auth methods
+func readMethods(r io.Reader) ([]byte, error) {
+	header := []byte{0}
+	if _, err := r.Read(header); err != nil {
+		return nil, err
+	}
+
+	numMethods := int(header[0])
+	methods := make([]byte, numMethods)
+	_, err := io.ReadAtLeast(r, methods, numMethods)
+	return methods, err
+}

--- a/pkg/socks5/auth_test.go
+++ b/pkg/socks5/auth_test.go
@@ -1,0 +1,119 @@
+package socks5
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNoAuth(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{1, NoAuth})
+	var resp bytes.Buffer
+
+	s, _ := New(&Config{})
+	ctx, err := s.authenticate(&resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ctx.Method != NoAuth {
+		t.Fatal("Invalid Context Method")
+	}
+
+	out := resp.Bytes()
+	if !bytes.Equal(out, []byte{socks5Version, NoAuth}) {
+		t.Fatalf("bad: %v", out)
+	}
+}
+
+func TestPasswordAuth_Valid(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{2, NoAuth, UserPassAuth})
+	req.Write([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
+	var resp bytes.Buffer
+
+	cred := StaticCredentials{
+		"foo": "bar",
+	}
+
+	cator := UserPassAuthenticator{Credentials: cred}
+
+	s, _ := New(&Config{AuthMethods: []Authenticator{cator}})
+
+	ctx, err := s.authenticate(&resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ctx.Method != UserPassAuth {
+		t.Fatal("Invalid Context Method")
+	}
+
+	val, ok := ctx.Payload["Username"]
+	if !ok {
+		t.Fatal("Missing key Username in auth context's payload")
+	}
+
+	if val != "foo" {
+		t.Fatal("Invalid Username in auth context's payload")
+	}
+
+	out := resp.Bytes()
+	if !bytes.Equal(out, []byte{socks5Version, UserPassAuth, 1, authSuccess}) {
+		t.Fatalf("bad: %v", out)
+	}
+}
+
+func TestPasswordAuth_Invalid(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{2, NoAuth, UserPassAuth})
+	req.Write([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'z'})
+	var resp bytes.Buffer
+
+	cred := StaticCredentials{
+		"foo": "bar",
+	}
+	cator := UserPassAuthenticator{Credentials: cred}
+	s, _ := New(&Config{AuthMethods: []Authenticator{cator}})
+
+	ctx, err := s.authenticate(&resp, req)
+	if err != UserAuthFailed {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ctx != nil {
+		t.Fatal("Invalid Context Method")
+	}
+
+	out := resp.Bytes()
+	if !bytes.Equal(out, []byte{socks5Version, UserPassAuth, 1, authFailure}) {
+		t.Fatalf("bad: %v", out)
+	}
+}
+
+func TestNoSupportedAuth(t *testing.T) {
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{1, NoAuth})
+	var resp bytes.Buffer
+
+	cred := StaticCredentials{
+		"foo": "bar",
+	}
+	cator := UserPassAuthenticator{Credentials: cred}
+
+	s, _ := New(&Config{AuthMethods: []Authenticator{cator}})
+
+	ctx, err := s.authenticate(&resp, req)
+	if err != NoSupportedAuth {
+		t.Fatalf("err: %v", err)
+	}
+
+	if ctx != nil {
+		t.Fatal("Invalid Context Method")
+	}
+
+	out := resp.Bytes()
+	if !bytes.Equal(out, []byte{socks5Version, noAcceptable}) {
+		t.Fatalf("bad: %v", out)
+	}
+}

--- a/pkg/socks5/credentials.go
+++ b/pkg/socks5/credentials.go
@@ -1,0 +1,17 @@
+package socks5
+
+// CredentialStore is used to support user/pass authentication
+type CredentialStore interface {
+	Valid(user, password string) bool
+}
+
+// StaticCredentials enables using a map directly as a credential store
+type StaticCredentials map[string]string
+
+func (s StaticCredentials) Valid(user, password string) bool {
+	pass, ok := s[user]
+	if !ok {
+		return false
+	}
+	return password == pass
+}

--- a/pkg/socks5/credentials_test.go
+++ b/pkg/socks5/credentials_test.go
@@ -1,0 +1,24 @@
+package socks5
+
+import (
+	"testing"
+)
+
+func TestStaticCredentials(t *testing.T) {
+	creds := StaticCredentials{
+		"foo": "bar",
+		"baz": "",
+	}
+
+	if !creds.Valid("foo", "bar") {
+		t.Fatalf("expect valid")
+	}
+
+	if !creds.Valid("baz", "") {
+		t.Fatalf("expect valid")
+	}
+
+	if creds.Valid("foo", "") {
+		t.Fatalf("expect invalid")
+	}
+}

--- a/pkg/socks5/request.go
+++ b/pkg/socks5/request.go
@@ -1,0 +1,364 @@
+package socks5
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	ConnectCommand   = uint8(1)
+	BindCommand      = uint8(2)
+	AssociateCommand = uint8(3)
+	ipv4Address      = uint8(1)
+	fqdnAddress      = uint8(3)
+	ipv6Address      = uint8(4)
+)
+
+const (
+	successReply uint8 = iota
+	serverFailure
+	ruleFailure
+	networkUnreachable
+	hostUnreachable
+	connectionRefused
+	ttlExpired
+	commandNotSupported
+	addrTypeNotSupported
+)
+
+var (
+	unrecognizedAddrType = fmt.Errorf("Unrecognized address type")
+)
+
+// AddressRewriter is used to rewrite a destination transparently
+type AddressRewriter interface {
+	Rewrite(ctx context.Context, request *Request) (context.Context, *AddrSpec)
+}
+
+// AddrSpec is used to return the target AddrSpec
+// which may be specified as IPv4, IPv6, or a FQDN
+type AddrSpec struct {
+	FQDN string
+	IP   net.IP
+	Port int
+}
+
+func (a *AddrSpec) String() string {
+	if a.FQDN != "" {
+		return fmt.Sprintf("%s (%s):%d", a.FQDN, a.IP, a.Port)
+	}
+	return fmt.Sprintf("%s:%d", a.IP, a.Port)
+}
+
+// Address returns a string suitable to dial; prefer returning IP-based
+// address, fallback to FQDN
+func (a AddrSpec) Address() string {
+	if 0 != len(a.IP) {
+		return net.JoinHostPort(a.IP.String(), strconv.Itoa(a.Port))
+	}
+	return net.JoinHostPort(a.FQDN, strconv.Itoa(a.Port))
+}
+
+// A Request represents request received by a server
+type Request struct {
+	// Protocol version
+	Version uint8
+	// Requested command
+	Command uint8
+	// AuthContext provided during negotiation
+	AuthContext *AuthContext
+	// AddrSpec of the the network that sent the request
+	RemoteAddr *AddrSpec
+	// AddrSpec of the desired destination
+	DestAddr *AddrSpec
+	// AddrSpec of the actual destination (might be affected by rewrite)
+	realDestAddr *AddrSpec
+	bufConn      io.Reader
+}
+
+type conn interface {
+	Write([]byte) (int, error)
+	RemoteAddr() net.Addr
+}
+
+// NewRequest creates a new Request from the tcp connection
+func NewRequest(bufConn io.Reader) (*Request, error) {
+	// Read the version byte
+	header := []byte{0, 0, 0}
+	if _, err := io.ReadAtLeast(bufConn, header, 3); err != nil {
+		return nil, fmt.Errorf("Failed to get command version: %v", err)
+	}
+
+	// Ensure we are compatible
+	if header[0] != socks5Version {
+		return nil, fmt.Errorf("Unsupported command version: %v", header[0])
+	}
+
+	// Read in the destination address
+	dest, err := readAddrSpec(bufConn)
+	if err != nil {
+		return nil, err
+	}
+
+	request := &Request{
+		Version:  socks5Version,
+		Command:  header[1],
+		DestAddr: dest,
+		bufConn:  bufConn,
+	}
+
+	return request, nil
+}
+
+// handleRequest is used for request processing after authentication
+func (s *Server) handleRequest(req *Request, conn conn) error {
+	ctx := context.Background()
+
+	// Resolve the address if we have a FQDN
+	dest := req.DestAddr
+	if dest.FQDN != "" {
+		ctx_, addr, err := s.config.Resolver.Resolve(ctx, dest.FQDN)
+		if err != nil {
+			if err := sendReply(conn, hostUnreachable, nil); err != nil {
+				return fmt.Errorf("Failed to send reply: %v", err)
+			}
+			return fmt.Errorf("Failed to resolve destination '%v': %v", dest.FQDN, err)
+		}
+		ctx = ctx_
+		dest.IP = addr
+	}
+
+	// Apply any address rewrites
+	req.realDestAddr = req.DestAddr
+	if s.config.Rewriter != nil {
+		ctx, req.realDestAddr = s.config.Rewriter.Rewrite(ctx, req)
+	}
+
+	// Switch on the command
+	switch req.Command {
+	case ConnectCommand:
+		return s.handleConnect(ctx, conn, req)
+	case BindCommand:
+		return s.handleBind(ctx, conn, req)
+	case AssociateCommand:
+		return s.handleAssociate(ctx, conn, req)
+	default:
+		if err := sendReply(conn, commandNotSupported, nil); err != nil {
+			return fmt.Errorf("Failed to send reply: %v", err)
+		}
+		return fmt.Errorf("Unsupported command: %v", req.Command)
+	}
+}
+
+// handleConnect is used to handle a connect command
+func (s *Server) handleConnect(ctx context.Context, conn conn, req *Request) error {
+	// Check if this is allowed
+	if ctx_, ok := s.config.Rules.Allow(ctx, req); !ok {
+		if err := sendReply(conn, ruleFailure, nil); err != nil {
+			return fmt.Errorf("Failed to send reply: %v", err)
+		}
+		return fmt.Errorf("Connect to %v blocked by rules", req.DestAddr)
+	} else {
+		ctx = ctx_
+	}
+
+	// Attempt to connect
+	dial := s.config.Dial
+	if dial == nil {
+		dial = func(ctx context.Context, net_, addr string) (net.Conn, error) {
+			return net.Dial(net_, addr)
+		}
+	}
+	target, err := dial(ctx, "tcp", req.realDestAddr.Address())
+	if err != nil {
+		msg := err.Error()
+		resp := hostUnreachable
+		if strings.Contains(msg, "refused") {
+			resp = connectionRefused
+		} else if strings.Contains(msg, "network is unreachable") {
+			resp = networkUnreachable
+		}
+		if err := sendReply(conn, resp, nil); err != nil {
+			return fmt.Errorf("Failed to send reply: %v", err)
+		}
+		return fmt.Errorf("Connect to %v failed: %v", req.DestAddr, err)
+	}
+	defer target.Close()
+
+	// Send success
+	local := target.LocalAddr().(*net.TCPAddr)
+	bind := AddrSpec{IP: local.IP, Port: local.Port}
+	if err := sendReply(conn, successReply, &bind); err != nil {
+		return fmt.Errorf("Failed to send reply: %v", err)
+	}
+
+	// Start proxying
+	errCh := make(chan error, 2)
+	go proxy(target, req.bufConn, errCh)
+	go proxy(conn, target, errCh)
+
+	// Wait
+	for i := 0; i < 2; i++ {
+		e := <-errCh
+		if e != nil {
+			// return from this function closes target (and conn).
+			return e
+		}
+	}
+	return nil
+}
+
+// handleBind is used to handle a connect command
+func (s *Server) handleBind(ctx context.Context, conn conn, req *Request) error {
+	// Check if this is allowed
+	if ctx_, ok := s.config.Rules.Allow(ctx, req); !ok {
+		if err := sendReply(conn, ruleFailure, nil); err != nil {
+			return fmt.Errorf("Failed to send reply: %v", err)
+		}
+		return fmt.Errorf("Bind to %v blocked by rules", req.DestAddr)
+	} else {
+		ctx = ctx_
+	}
+
+	// TODO: Support bind
+	if err := sendReply(conn, commandNotSupported, nil); err != nil {
+		return fmt.Errorf("Failed to send reply: %v", err)
+	}
+	return nil
+}
+
+// handleAssociate is used to handle a connect command
+func (s *Server) handleAssociate(ctx context.Context, conn conn, req *Request) error {
+	// Check if this is allowed
+	if ctx_, ok := s.config.Rules.Allow(ctx, req); !ok {
+		if err := sendReply(conn, ruleFailure, nil); err != nil {
+			return fmt.Errorf("Failed to send reply: %v", err)
+		}
+		return fmt.Errorf("Associate to %v blocked by rules", req.DestAddr)
+	} else {
+		ctx = ctx_
+	}
+
+	// TODO: Support associate
+	if err := sendReply(conn, commandNotSupported, nil); err != nil {
+		return fmt.Errorf("Failed to send reply: %v", err)
+	}
+	return nil
+}
+
+// readAddrSpec is used to read AddrSpec.
+// Expects an address type byte, follwed by the address and port
+func readAddrSpec(r io.Reader) (*AddrSpec, error) {
+	d := &AddrSpec{}
+
+	// Get the address type
+	addrType := []byte{0}
+	if _, err := r.Read(addrType); err != nil {
+		return nil, err
+	}
+
+	// Handle on a per type basis
+	switch addrType[0] {
+	case ipv4Address:
+		addr := make([]byte, 4)
+		if _, err := io.ReadAtLeast(r, addr, len(addr)); err != nil {
+			return nil, err
+		}
+		d.IP = net.IP(addr)
+
+	case ipv6Address:
+		addr := make([]byte, 16)
+		if _, err := io.ReadAtLeast(r, addr, len(addr)); err != nil {
+			return nil, err
+		}
+		d.IP = net.IP(addr)
+
+	case fqdnAddress:
+		if _, err := r.Read(addrType); err != nil {
+			return nil, err
+		}
+		addrLen := int(addrType[0])
+		fqdn := make([]byte, addrLen)
+		if _, err := io.ReadAtLeast(r, fqdn, addrLen); err != nil {
+			return nil, err
+		}
+		d.FQDN = string(fqdn)
+
+	default:
+		return nil, unrecognizedAddrType
+	}
+
+	// Read the port
+	port := []byte{0, 0}
+	if _, err := io.ReadAtLeast(r, port, 2); err != nil {
+		return nil, err
+	}
+	d.Port = (int(port[0]) << 8) | int(port[1])
+
+	return d, nil
+}
+
+// sendReply is used to send a reply message
+func sendReply(w io.Writer, resp uint8, addr *AddrSpec) error {
+	// Format the address
+	var addrType uint8
+	var addrBody []byte
+	var addrPort uint16
+	switch {
+	case addr == nil:
+		addrType = ipv4Address
+		addrBody = []byte{0, 0, 0, 0}
+		addrPort = 0
+
+	case addr.FQDN != "":
+		addrType = fqdnAddress
+		addrBody = append([]byte{byte(len(addr.FQDN))}, addr.FQDN...)
+		addrPort = uint16(addr.Port)
+
+	case addr.IP.To4() != nil:
+		addrType = ipv4Address
+		addrBody = []byte(addr.IP.To4())
+		addrPort = uint16(addr.Port)
+
+	case addr.IP.To16() != nil:
+		addrType = ipv6Address
+		addrBody = []byte(addr.IP.To16())
+		addrPort = uint16(addr.Port)
+
+	default:
+		return fmt.Errorf("Failed to format address: %v", addr)
+	}
+
+	// Format the message
+	msg := make([]byte, 6+len(addrBody))
+	msg[0] = socks5Version
+	msg[1] = resp
+	msg[2] = 0 // Reserved
+	msg[3] = addrType
+	copy(msg[4:], addrBody)
+	msg[4+len(addrBody)] = byte(addrPort >> 8)
+	msg[4+len(addrBody)+1] = byte(addrPort & 0xff)
+
+	// Send the message
+	_, err := w.Write(msg)
+	return err
+}
+
+type closeWriter interface {
+	CloseWrite() error
+}
+
+// proxy is used to suffle data from src to destination, and sends errors
+// down a dedicated channel
+func proxy(dst io.Writer, src io.Reader, errCh chan error) {
+	_, err := io.Copy(dst, src)
+	if tcpConn, ok := dst.(closeWriter); ok {
+		tcpConn.CloseWrite()
+	}
+	errCh <- err
+}

--- a/pkg/socks5/request.go
+++ b/pkg/socks5/request.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 const (

--- a/pkg/socks5/request.go
+++ b/pkg/socks5/request.go
@@ -155,6 +155,9 @@ func (s *Server) handleRequest(req *Request, conn conn) error {
 	}
 }
 
+// fakeAddr is used when the destaddr isn't a real net.TCPAddr
+var fakeAddr = net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1000}
+
 // handleConnect is used to handle a connect command
 func (s *Server) handleConnect(ctx context.Context, conn conn, req *Request) error {
 	// Check if this is allowed
@@ -190,8 +193,14 @@ func (s *Server) handleConnect(ctx context.Context, conn conn, req *Request) err
 	}
 	defer target.Close()
 
-	// Send success
-	local := target.LocalAddr().(*net.TCPAddr)
+	// Send success (pathced to allow )
+	var local *net.TCPAddr
+	if v, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		local = v
+	} else {
+		local = &fakeAddr
+	}
+
 	bind := AddrSpec{IP: local.IP, Port: local.Port}
 	if err := sendReply(conn, successReply, &bind); err != nil {
 		return fmt.Errorf("Failed to send reply: %v", err)

--- a/pkg/socks5/request_test.go
+++ b/pkg/socks5/request_test.go
@@ -1,0 +1,169 @@
+package socks5
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+type MockConn struct {
+	buf bytes.Buffer
+}
+
+func (m *MockConn) Write(b []byte) (int, error) {
+	return m.buf.Write(b)
+}
+
+func (m *MockConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: []byte{127, 0, 0, 1}, Port: 65432}
+}
+
+func TestRequest_Connect(t *testing.T) {
+	// Create a local listener
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 4)
+		if _, err := io.ReadAtLeast(conn, buf, 4); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if !bytes.Equal(buf, []byte("ping")) {
+			t.Fatalf("bad: %v", buf)
+		}
+		conn.Write([]byte("pong"))
+	}()
+	lAddr := l.Addr().(*net.TCPAddr)
+
+	// Make server
+	s := &Server{config: &Config{
+		Rules:    PermitAll(),
+		Resolver: DNSResolver{},
+		Logger:   log.New(os.Stdout, "", log.LstdFlags),
+	}}
+
+	// Create the connect request
+	buf := bytes.NewBuffer(nil)
+	buf.Write([]byte{5, 1, 0, 1, 127, 0, 0, 1})
+
+	port := []byte{0, 0}
+	binary.BigEndian.PutUint16(port, uint16(lAddr.Port))
+	buf.Write(port)
+
+	// Send a ping
+	buf.Write([]byte("ping"))
+
+	// Handle the request
+	resp := &MockConn{}
+	req, err := NewRequest(buf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if err := s.handleRequest(req, resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Verify response
+	out := resp.buf.Bytes()
+	expected := []byte{
+		5,
+		0,
+		0,
+		1,
+		127, 0, 0, 1,
+		0, 0,
+		'p', 'o', 'n', 'g',
+	}
+
+	// Ignore the port for both
+	out[8] = 0
+	out[9] = 0
+
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("bad: %v %v", out, expected)
+	}
+}
+
+func TestRequest_Connect_RuleFail(t *testing.T) {
+	// Create a local listener
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 4)
+		if _, err := io.ReadAtLeast(conn, buf, 4); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if !bytes.Equal(buf, []byte("ping")) {
+			t.Fatalf("bad: %v", buf)
+		}
+		conn.Write([]byte("pong"))
+	}()
+	lAddr := l.Addr().(*net.TCPAddr)
+
+	// Make server
+	s := &Server{config: &Config{
+		Rules:    PermitNone(),
+		Resolver: DNSResolver{},
+		Logger:   log.New(os.Stdout, "", log.LstdFlags),
+	}}
+
+	// Create the connect request
+	buf := bytes.NewBuffer(nil)
+	buf.Write([]byte{5, 1, 0, 1, 127, 0, 0, 1})
+
+	port := []byte{0, 0}
+	binary.BigEndian.PutUint16(port, uint16(lAddr.Port))
+	buf.Write(port)
+
+	// Send a ping
+	buf.Write([]byte("ping"))
+
+	// Handle the request
+	resp := &MockConn{}
+	req, err := NewRequest(buf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if err := s.handleRequest(req, resp); !strings.Contains(err.Error(), "blocked by rules") {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Verify response
+	out := resp.buf.Bytes()
+	expected := []byte{
+		5,
+		2,
+		0,
+		1,
+		0, 0, 0, 0,
+		0, 0,
+	}
+
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("bad: %v %v", out, expected)
+	}
+}

--- a/pkg/socks5/resolver.go
+++ b/pkg/socks5/resolver.go
@@ -1,0 +1,23 @@
+package socks5
+
+import (
+	"net"
+
+	"golang.org/x/net/context"
+)
+
+// NameResolver is used to implement custom name resolution
+type NameResolver interface {
+	Resolve(ctx context.Context, name string) (context.Context, net.IP, error)
+}
+
+// DNSResolver uses the system DNS to resolve host names
+type DNSResolver struct{}
+
+func (d DNSResolver) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
+	addr, err := net.ResolveIPAddr("ip", name)
+	if err != nil {
+		return ctx, nil, err
+	}
+	return ctx, addr.IP, err
+}

--- a/pkg/socks5/resolver.go
+++ b/pkg/socks5/resolver.go
@@ -3,7 +3,7 @@ package socks5
 import (
 	"net"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // NameResolver is used to implement custom name resolution

--- a/pkg/socks5/resolver_test.go
+++ b/pkg/socks5/resolver_test.go
@@ -1,0 +1,21 @@
+package socks5
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestDNSResolver(t *testing.T) {
+	d := DNSResolver{}
+	ctx := context.Background()
+
+	_, addr, err := d.Resolve(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !addr.IsLoopback() {
+		t.Fatalf("expected loopback")
+	}
+}

--- a/pkg/socks5/resolver_test.go
+++ b/pkg/socks5/resolver_test.go
@@ -3,7 +3,7 @@ package socks5
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestDNSResolver(t *testing.T) {

--- a/pkg/socks5/ruleset.go
+++ b/pkg/socks5/ruleset.go
@@ -1,0 +1,41 @@
+package socks5
+
+import (
+	"golang.org/x/net/context"
+)
+
+// RuleSet is used to provide custom rules to allow or prohibit actions
+type RuleSet interface {
+	Allow(ctx context.Context, req *Request) (context.Context, bool)
+}
+
+// PermitAll returns a RuleSet which allows all types of connections
+func PermitAll() RuleSet {
+	return &PermitCommand{true, true, true}
+}
+
+// PermitNone returns a RuleSet which disallows all types of connections
+func PermitNone() RuleSet {
+	return &PermitCommand{false, false, false}
+}
+
+// PermitCommand is an implementation of the RuleSet which
+// enables filtering supported commands
+type PermitCommand struct {
+	EnableConnect   bool
+	EnableBind      bool
+	EnableAssociate bool
+}
+
+func (p *PermitCommand) Allow(ctx context.Context, req *Request) (context.Context, bool) {
+	switch req.Command {
+	case ConnectCommand:
+		return ctx, p.EnableConnect
+	case BindCommand:
+		return ctx, p.EnableBind
+	case AssociateCommand:
+		return ctx, p.EnableAssociate
+	}
+
+	return ctx, false
+}

--- a/pkg/socks5/ruleset.go
+++ b/pkg/socks5/ruleset.go
@@ -1,7 +1,7 @@
 package socks5
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // RuleSet is used to provide custom rules to allow or prohibit actions

--- a/pkg/socks5/ruleset_test.go
+++ b/pkg/socks5/ruleset_test.go
@@ -1,0 +1,24 @@
+package socks5
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestPermitCommand(t *testing.T) {
+	ctx := context.Background()
+	r := &PermitCommand{true, false, false}
+
+	if _, ok := r.Allow(ctx, &Request{Command: ConnectCommand}); !ok {
+		t.Fatalf("expect connect")
+	}
+
+	if _, ok := r.Allow(ctx, &Request{Command: BindCommand}); ok {
+		t.Fatalf("do not expect bind")
+	}
+
+	if _, ok := r.Allow(ctx, &Request{Command: AssociateCommand}); ok {
+		t.Fatalf("do not expect associate")
+	}
+}

--- a/pkg/socks5/ruleset_test.go
+++ b/pkg/socks5/ruleset_test.go
@@ -3,7 +3,7 @@ package socks5
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestPermitCommand(t *testing.T) {

--- a/pkg/socks5/socks5.go
+++ b/pkg/socks5/socks5.go
@@ -1,0 +1,169 @@
+package socks5
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	socks5Version = uint8(5)
+)
+
+// Config is used to setup and configure a Server
+type Config struct {
+	// AuthMethods can be provided to implement custom authentication
+	// By default, "auth-less" mode is enabled.
+	// For password-based auth use UserPassAuthenticator.
+	AuthMethods []Authenticator
+
+	// If provided, username/password authentication is enabled,
+	// by appending a UserPassAuthenticator to AuthMethods. If not provided,
+	// and AUthMethods is nil, then "auth-less" mode is enabled.
+	Credentials CredentialStore
+
+	// Resolver can be provided to do custom name resolution.
+	// Defaults to DNSResolver if not provided.
+	Resolver NameResolver
+
+	// Rules is provided to enable custom logic around permitting
+	// various commands. If not provided, PermitAll is used.
+	Rules RuleSet
+
+	// Rewriter can be used to transparently rewrite addresses.
+	// This is invoked before the RuleSet is invoked.
+	// Defaults to NoRewrite.
+	Rewriter AddressRewriter
+
+	// BindIP is used for bind or udp associate
+	BindIP net.IP
+
+	// Logger can be used to provide a custom log target.
+	// Defaults to stdout.
+	Logger *log.Logger
+
+	// Optional function for dialing out
+	Dial func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+// Server is reponsible for accepting connections and handling
+// the details of the SOCKS5 protocol
+type Server struct {
+	config      *Config
+	authMethods map[uint8]Authenticator
+}
+
+// New creates a new Server and potentially returns an error
+func New(conf *Config) (*Server, error) {
+	// Ensure we have at least one authentication method enabled
+	if len(conf.AuthMethods) == 0 {
+		if conf.Credentials != nil {
+			conf.AuthMethods = []Authenticator{&UserPassAuthenticator{conf.Credentials}}
+		} else {
+			conf.AuthMethods = []Authenticator{&NoAuthAuthenticator{}}
+		}
+	}
+
+	// Ensure we have a DNS resolver
+	if conf.Resolver == nil {
+		conf.Resolver = DNSResolver{}
+	}
+
+	// Ensure we have a rule set
+	if conf.Rules == nil {
+		conf.Rules = PermitAll()
+	}
+
+	// Ensure we have a log target
+	if conf.Logger == nil {
+		conf.Logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+
+	server := &Server{
+		config: conf,
+	}
+
+	server.authMethods = make(map[uint8]Authenticator)
+
+	for _, a := range conf.AuthMethods {
+		server.authMethods[a.GetCode()] = a
+	}
+
+	return server, nil
+}
+
+// ListenAndServe is used to create a listener and serve on it
+func (s *Server) ListenAndServe(network, addr string) error {
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return err
+	}
+	return s.Serve(l)
+}
+
+// Serve is used to serve connections from a listener
+func (s *Server) Serve(l net.Listener) error {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		go s.ServeConn(conn)
+	}
+	return nil
+}
+
+// ServeConn is used to serve a single connection.
+func (s *Server) ServeConn(conn net.Conn) error {
+	defer conn.Close()
+	bufConn := bufio.NewReader(conn)
+
+	// Read the version byte
+	version := []byte{0}
+	if _, err := bufConn.Read(version); err != nil {
+		s.config.Logger.Printf("[ERR] socks: Failed to get version byte: %v", err)
+		return err
+	}
+
+	// Ensure we are compatible
+	if version[0] != socks5Version {
+		err := fmt.Errorf("Unsupported SOCKS version: %v", version)
+		s.config.Logger.Printf("[ERR] socks: %v", err)
+		return err
+	}
+
+	// Authenticate the connection
+	authContext, err := s.authenticate(conn, bufConn)
+	if err != nil {
+		err = fmt.Errorf("Failed to authenticate: %v", err)
+		s.config.Logger.Printf("[ERR] socks: %v", err)
+		return err
+	}
+
+	request, err := NewRequest(bufConn)
+	if err != nil {
+		if err == unrecognizedAddrType {
+			if err := sendReply(conn, addrTypeNotSupported, nil); err != nil {
+				return fmt.Errorf("Failed to send reply: %v", err)
+			}
+		}
+		return fmt.Errorf("Failed to read destination address: %v", err)
+	}
+	request.AuthContext = authContext
+	if client, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		request.RemoteAddr = &AddrSpec{IP: client.IP, Port: client.Port}
+	}
+
+	// Process the client request
+	if err := s.handleRequest(request, conn); err != nil {
+		err = fmt.Errorf("Failed to handle request: %v", err)
+		s.config.Logger.Printf("[ERR] socks: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/socks5/socks5.go
+++ b/pkg/socks5/socks5.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"os"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 const (

--- a/pkg/socks5/socks5.go
+++ b/pkg/socks5/socks5.go
@@ -160,6 +160,12 @@ func (s *Server) ServeConn(conn net.Conn) error {
 
 	// Process the client request
 	if err := s.handleRequest(request, conn); err != nil {
+		// TODO: The http server is expected to close the connection after
+		// serving the request so we are ignoring the "connection closed" error
+		// for now. This might not be the best way to handle this situation.
+		if err.Error() == "connection closed" {
+			return nil
+		}
 		err = fmt.Errorf("Failed to handle request: %v", err)
 		s.config.Logger.Printf("[ERR] socks: %v", err)
 		return err

--- a/pkg/socks5/socks5_test.go
+++ b/pkg/socks5/socks5_test.go
@@ -1,0 +1,110 @@
+package socks5
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSOCKS5_Connect(t *testing.T) {
+	// Create a local listener
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 4)
+		if _, err := io.ReadAtLeast(conn, buf, 4); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if !bytes.Equal(buf, []byte("ping")) {
+			t.Fatalf("bad: %v", buf)
+		}
+		conn.Write([]byte("pong"))
+	}()
+	lAddr := l.Addr().(*net.TCPAddr)
+
+	// Create a socks server
+	creds := StaticCredentials{
+		"foo": "bar",
+	}
+	cator := UserPassAuthenticator{Credentials: creds}
+	conf := &Config{
+		AuthMethods: []Authenticator{cator},
+		Logger:      log.New(os.Stdout, "", log.LstdFlags),
+	}
+	serv, err := New(conf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Start listening
+	go func() {
+		if err := serv.ListenAndServe("tcp", "127.0.0.1:12365"); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	// Get a local conn
+	conn, err := net.Dial("tcp", "127.0.0.1:12365")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Connect, auth and connec to local
+	req := bytes.NewBuffer(nil)
+	req.Write([]byte{5})
+	req.Write([]byte{2, NoAuth, UserPassAuth})
+	req.Write([]byte{1, 3, 'f', 'o', 'o', 3, 'b', 'a', 'r'})
+	req.Write([]byte{5, 1, 0, 1, 127, 0, 0, 1})
+
+	port := []byte{0, 0}
+	binary.BigEndian.PutUint16(port, uint16(lAddr.Port))
+	req.Write(port)
+
+	// Send a ping
+	req.Write([]byte("ping"))
+
+	// Send all the bytes
+	conn.Write(req.Bytes())
+
+	// Verify response
+	expected := []byte{
+		socks5Version, UserPassAuth,
+		1, authSuccess,
+		5,
+		0,
+		0,
+		1,
+		127, 0, 0, 1,
+		0, 0,
+		'p', 'o', 'n', 'g',
+	}
+	out := make([]byte, len(expected))
+
+	conn.SetDeadline(time.Now().Add(time.Second))
+	if _, err := io.ReadAtLeast(conn, out, len(out)); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ignore the port
+	out[12] = 0
+	out[13] = 0
+
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("bad: %v", out)
+	}
+}


### PR DESCRIPTION
Work in progress for #9 


## basic configuration

I'm working towards the configuration style below. The `ports:` field is based
on code for a docker-compose.yml `ports:"` parser from some docker package..

```yml

  myservice:
    method: http
    http:
      ports:
        - 8100-8120                  # myservice:8100 to myservice:8120
        - 192.168.1.1:8100-8120:8300 # myservice:8300 to myservice:8320

  myservice2:
    method: http
    http:
      port: 8100                     # myservice2:1 or myservice2:8100
```


## easy/safe unique scrape host names

The config below would create the same scrape target instance names
`myservice:1` and `myservice:2` for multiple actual hosts which isn't great and
can lead to accidental mix ups in Prometheus queries. 

```yml
 - job_name: 'myservice_host1'
    scrape_interval: 1s
    static_configs:
      - targets: ['myservice:1', 'myservice:2']
    scheme: https
    proxy_url: "socks5://host1:3000"
    metrics_path: /proxy
    tls_config:
        ...

 - job_name: 'myservice_host2'
    scrape_interval: 1s
    static_configs:
      - targets: ['myservice:1', 'myservice:2']
    scheme: https
    proxy_url: "socks5://host2:3000"
    metrics_path: /proxy
    tls_config:
        ...

```

While it is probably possible to avoid instance name collisions using
relabeling inside Prometheus I think it's best to be able to ensure instance
name uniqueness at the node level.

To solve this issue an optional `-socks.prefix` flag is introduced to
`exporter_exporter` which enforces a FQN prefix to the virtual host names.

If an `exporter_exporter` instance is started with `-socks.prefix
cool.host1` the scrape target would then look like this:


```yml
 - job_name: 'myservice_host1'
    scrape_interval: 1s
    static_configs:
      - targets: ['cool.host1.myservice:1', 'cool.host1.myservice:2']
    scheme: https
    proxy_url: "socks5://host1:3000"
    metrics_path: /proxy
    tls_config:
        ...

```

To lessen the requirements of manual node configuration An additional boolean
flag `-socks.auto-prefix` will try to set the prefix using `os.Hostname()`
returns unless it returns an empty string or error in which case start up will
be aborted by an fatal exit.


## command line options
right now it looks like this (the descriptions will be revised later):
```
  -socks.listen-address string
    	The address to listen on for accessing the metrics end points via made up internal host names.
  -socks.tls
    	Use TLS with the socks proxy (default true)
  -socks.prefix
        ...
  -socks.auto-prefix (default False)
        ...        
```

## (QUESTION) can not use socks method + TLS + non-TLS at the same time

Because `-socks.tls` and `-socks.listen-address` are combined the socks method
can not be enabled for both tls and non tls access simultaneously. I don't see
it useful to have both working at the same time but we have to change some
things if it should be supported.

## (QUESTION) should it be allowed to configure the same service multiple times?

I'm a bit skeptical of this feature since it complicates the rules for what a
valid configuration can be while not adding strong practical benefits.

**This question can be deferred since it can be added later if needed**


```yml
  myservice:
    method: http
    http:
      ports:
        - 8100-8120                  # myservice:8100 to myservice:8120
        - 192.168.1.1:8100-8120:8300 # myservice:8300 to myservice:8320

  myservice: # invalid config since port 8100 already was defined above
    method: http
    http:
      port: 8100

  myservice: # valid config since port 8400 isn't alloceted for myservice
    method: http
    http:
      ports:
      - "8101:8400"
```

For the directory based config `myservice.app1.yml` and `myservice.app2.yml`
would work for allowing multiple instances.


## (QUESTION) exposing multi port services for non socks methods

**This question can be deferred since it can be added later if needed**

I'm not sure if if is meaningful to implement the multiple ports per service
scheme for the regular http and https serving options via URL parameters. The
corresponding prometheus.yml would become very complicated. Could be useful if
one wants to use a web browser to easily view the exporters but that isn't easy
when using client certificates login anyway so maybe not a big win?
