### PR TITLE
return json if requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The advantages are:
 The exporter has three endpoints.
 
 - /: displays a list of all exporters with links to their metrics.
+  - Returns JSON if the header "Accept: application/json" is passed
 
 - /proxy: which takes the following parameters:
   - module: the name of the module from the configuration to execute.


### PR DESCRIPTION
We are currently exposing a list of all configured exporters in HTML which is great for human consumption.

Adding the ability to retrieve the same information in JSON format when the header `Accept: application/json` is passed. This can be used for a variety of integrations with other systems where needed. E.g. Consuming the exporter list for each asset in a CMDB.
