### PR TITLE
sort proxied metrics

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"sort"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -96,6 +97,8 @@ func (c execConfig) GatherWithContext(ctx context.Context, r *http.Request) prom
 		for _, mf := range mfs {
 			result = append(result, mf)
 		}
+
+		sort.Slice(result, func(i, j int) bool { return result[i].GetName() < result[j].GetName() })
 		return result, nil
 	}
 }

--- a/http.go
+++ b/http.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -83,6 +84,7 @@ func (c httpConfig) GatherWithContext(ctx context.Context, r *http.Request) prom
 			result = append(result, &mf)
 		}
 
+		sort.Slice(result, func(i, j int) bool { return result[i].GetName() < result[j].GetName() })
 		return result, nil
 	}
 }


### PR DESCRIPTION
Make output more human readable by sorting metrics by name after
[TextToMetricFamilies](https://godoc.org/github.com/prometheus/common/expfmt#TextParser.TextToMetricFamilies) of prometheus TextParses scrambles them