### PR TITLE
Don't overwrite config files on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ $(PACKAGE_FILE): prepare-package
 	  -a $(PACKAGE_ARCH) \
 	  -v $(PACKAGE_VERSION) \
 	  --iteration $(PACKAGE_REVISION) \
+	  --config-files /etc/$(BINNAME).yaml \
+	  --config-files /etc/init/$(BINNAME).conf \
+	  --config-files /etc/default/$(BINNAME) \
 	  -s dir \
 	  -p ../$(PACKAGE_FILE) \
 	  .


### PR DESCRIPTION
This solves the problem where the package would wipe out the existing configuration files when installed on machines that are managed by things such as Puppet or Chef. 

Tested this on a fork that builds .rpm packages, but haven't tested with .deb