### PR TITLE
Add metric for build_info

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,11 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var (
 	Version   = "unset"
@@ -8,7 +13,23 @@ var (
 	Branch    = "unset"
 	BuildUser = "unset"
 	BuildDate = "unset"
+	GoVersion = runtime.Version()
 )
+
+var (
+	buildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "build_info",
+			Help: "A metric with a constant '1' value labeled by version, revision, branch and goversion from which exporter_exporter was built.",
+		},
+		[]string{"version", "revision", "branch", "goversion"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(buildInfo)
+	buildInfo.WithLabelValues(Version, Revision, Branch, GoVersion).Set(1)
+}
 
 func versionStr() string {
 	return fmt.Sprintf("%s-%s (from %s, built by %s on %s)", Version, Revision, Branch, BuildUser, BuildDate)


### PR DESCRIPTION
Exposing the `build_info` metric (commonly found in exporters) that provides the version, revision, branch, and goversion of exporter_exporter in the labels.

This really helps when doing large scale upgrades or troubleshooting.