### PR TITLE
Manage Windows Service after reading flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -241,7 +241,6 @@ func runListener(ctx context.Context, name string, lsnr net.Listener, handler ht
 	srvr := http.Server{
 		Handler: handler,
 	}
-	manageService()
 	go func() {
 		<-ctx.Done()
 		srvr.Shutdown(context.Background())
@@ -263,6 +262,7 @@ func main() {
 	}()
 
 	flag.Parse()
+	manageService()
 
 	if *printVersion {
 		fmt.Fprintf(os.Stderr, "Version: %s\n", versionStr())

--- a/service_windows.go
+++ b/service_windows.go
@@ -91,7 +91,7 @@ func installService(name, desc string) error {
 	flag.Visit(func(f *flag.Flag) {
 		if f.Name != "winsvc" {
 			serviceArgs = append(serviceArgs, fmt.Sprintf("-%s", f.Name))
-			if f.Value.String() != "" {
+			if f.Value.String() != "true" {
 				serviceArgs = append(serviceArgs, f.Value.String())
 			}
 		}


### PR DESCRIPTION
This fixes an issue where you need to have/pass a valid configuration file when attempting to execute `--winsvc install/remove/start/stop`.

As for the flags, boolean flags that are passed with no actual value still end up containing "True" in the Windows service options and cause expexp not to start. Let's pass the key and not the value for those.