### PR TITLE
Fix regex in Prometheus config example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ When this is working, configure your prometheus server to use https. Example:
       - source_labels: [__address__]
         target_label: instance
       - source_labels: [__address__]
-        regex: '[^:]+'
+        regex: '([^:]+)'
         target_label: __address__
         replacement: '${1}:9998'
 ```


### PR DESCRIPTION
The variable `${1}` doesn't reference any match group in the regex, leading to a `__address__` without the host part.

This commit fixes that.