### PR TITLE
support basic http auth

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,6 +60,8 @@ type httpConfig struct {
 	Scheme                string                 `yaml:"scheme"`                   // http
 	Address               string                 `yaml:"address"`                  // 127.0.0.1
 	Headers               map[string]string      `yaml:"headers"`                  // no default
+	BasicAuthUsername     string                 `yaml:"basic_auth_username"`      // no default
+	BasicAuthPassword     string                 `yaml:"basic_auth_password"`      // no default
 	XXX                   map[string]interface{} `yaml:",inline"`
 
 	tlsConfig              *tls.Config

--- a/http.go
+++ b/http.go
@@ -74,6 +74,9 @@ func (cfg moduleConfig) getReverseProxyDirectorFunc() (func(*http.Request), erro
 		r.URL.Scheme = cfg.HTTP.Scheme
 		r.URL.Host = net.JoinHostPort(cfg.HTTP.Address, strconv.Itoa(cfg.HTTP.Port))
 		r.URL.Path = base.Path
+		if cfg.HTTP.BasicAuthUsername != "" && cfg.HTTP.BasicAuthPassword != "" {
+			r.SetBasicAuth(cfg.HTTP.BasicAuthUsername, cfg.HTTP.BasicAuthPassword)
+		}
 	}, nil
 }
 


### PR DESCRIPTION
Add support for basic HTTP auth, my concrete usecase is dnsdist which has basic auth on the builtin prometheus metrics, tested and works, hope you can use it. Fixes #58 (for me at least :))