### PR TITLE
Added discovery feature

### DIFF
--- a/config.go
+++ b/config.go
@@ -96,8 +96,9 @@ type discoveryConfig struct {
 }
 
 type exporter struct {
-	Port int    `yaml:"port"`
-	Path string `yaml:"path"`
+	Port   int    `yaml:"port"`
+	Path   string `yaml:"path"`
+	Verify *bool  `yaml:"verify"`
 }
 
 type httpConfig struct {

--- a/config.go
+++ b/config.go
@@ -28,8 +28,7 @@ import (
 )
 
 type config struct {
-	Global struct {
-	}
+	Global    struct{}
 	Modules   map[string]*moduleConfig
 	Discovery *discoveryConfig
 	XXX       map[string]interface{} `yaml:",inline"`

--- a/discovery.go
+++ b/discovery.go
@@ -87,10 +87,15 @@ func runDiscovery(ctx context.Context, cfg *config) {
 			continue
 		}
 		if alive(ctx, ip, exp.Port, exp.Path) {
+			verify := true
+			if exp.Verify != nil && *exp.Verify == false {
+				verify = false
+			}
 			mc := &moduleConfig{
 				Method: "http",
 				HTTP: httpConfig{
 					Port:    exp.Port,
+					Verify:  &verify,
 					Address: cfg.Discovery.Address,
 				},
 			}

--- a/discovery.go
+++ b/discovery.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var client = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec only cockroach at the moment
+	},
+}
+
+func alive(parentCtx context.Context, host string, portI int, path string) bool {
+	port := strconv.Itoa(portI)
+	if path != "" {
+		u := fmt.Sprintf(path, net.JoinHostPort(host, port))
+
+		ctx, cancel := context.WithTimeout(parentCtx, time.Second*3)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+		if err != nil {
+			logrus.Errorf("error creating request: %s", err)
+			return false
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+
+		r := bufio.NewReader(resp.Body)
+		for i := 0; i < 10; i++ {
+			line, _, err := r.ReadLine()
+			if err != nil {
+				return false
+			}
+			if bytes.Contains(line, []byte("# TYPE")) {
+				return true
+			}
+		}
+		return false
+	}
+
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+
+	if conn != nil {
+		conn.Close()
+		return true
+	}
+	return false
+}
+
+func startDiscovery(ctx context.Context, cfg *config) {
+	if cfg.Modules == nil { // make sure we have modules config if we are running only in discovery mode
+		cfg.Modules = make(map[string]*moduleConfig)
+	}
+	ticker := time.NewTicker(cfg.Discovery.interval)
+	runDiscovery(ctx, cfg)
+	for {
+		select {
+		case <-ticker.C:
+			runDiscovery(ctx, cfg)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func runDiscovery(ctx context.Context, cfg *config) {
+	ip := cfg.Discovery.Address
+	for name, exp := range cfg.Discovery.Exporters {
+		if alive(ctx, ip, exp.Port, exp.Path) {
+			mc := &moduleConfig{
+				Method: "http",
+				HTTP: httpConfig{
+					Port:    exp.Port,
+					Address: cfg.Discovery.Address,
+				},
+			}
+			if exp.Path != "" {
+				u, err := url.Parse(fmt.Sprintf(exp.Path, net.JoinHostPort(ip, strconv.Itoa(exp.Port))))
+				if err != nil {
+					logrus.Error(err)
+					continue
+				}
+				mc.HTTP.Scheme = u.Scheme
+				mc.HTTP.Path = u.Path
+			}
+
+			err := checkModuleConfig(name, mc)
+			if err != nil {
+				logrus.Error(err)
+			}
+			cfg.addModule(name, mc)
+			continue
+		}
+		logrus.Debugf("%s:%d was not open", ip, exp.Port)
+	}
+}

--- a/discovery.go
+++ b/discovery.go
@@ -83,6 +83,9 @@ func startDiscovery(ctx context.Context, cfg *config) {
 func runDiscovery(ctx context.Context, cfg *config) {
 	ip := cfg.Discovery.Address
 	for name, exp := range cfg.Discovery.Exporters {
+		if m := cfg.getModule(name); m != nil {
+			continue
+		}
 		if alive(ctx, ip, exp.Port, exp.Path) {
 			mc := &moduleConfig{
 				Method: "http",

--- a/example_discovery.yml
+++ b/example_discovery.yml
@@ -1,0 +1,8 @@
+discovery: 
+  enabled: true
+  exporters: 
+    node:
+      port: 9100
+    minio:
+      port: 9091
+      path: "http://%s/minio/prometheus/metrics"

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 )
 
-go 1.14
+go 1.15

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aktau/github-release v0.7.2 h1:la7AnShr2MQPIlBEcRA9MPbI8av0YFmpFP9WM5EoqJs=
-github.com/aktau/github-release v0.7.2/go.mod h1:cPkP83iRnV8pAJyQlQ4vjLJoC+JE+aT5sOrYz3sTsX0=
 github.com/aktau/github-release v0.10.0 h1:4U+9iRM7n094ZCROdnoah084FDmdQ01hwQsz0f0hwIw=
 github.com/aktau/github-release v0.10.0/go.mod h1:cPkP83iRnV8pAJyQlQ4vjLJoC+JE+aT5sOrYz3sTsX0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=

--- a/http.go
+++ b/http.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// Msg to send in response body when verification of proxied server
-	// response is failed
+	// response is failed.
 	VerificationErrorMsg = "Internal Server Error: " +
 		"Response from proxied server failed verification. " +
 		"See server logs for details"
@@ -147,7 +147,7 @@ func (cfg moduleConfig) getReverseProxyErrorHandlerFunc() func(http.ResponseWrit
 	}
 }
 
-// BearerAuthMiddleware
+// BearerAuthMiddleware.
 type BearerAuthMiddleware struct {
 	http.Handler
 	Token string

--- a/main.go
+++ b/main.go
@@ -170,6 +170,13 @@ cfgDirs:
 			cfg.addModule(mn, mcfg)
 		}
 	}
+	if cfg.Discovery == nil {
+		cfg.Discovery =
+			&discoveryConfig{
+				Exporters: make(map[string]*exporter),
+			}
+	}
+
 	if len(cfg.GetModules()) == 0 && cfg.Discovery.Enabled == false {
 		log.Errorln("no modules loaded from any config file")
 	}

--- a/version.go
+++ b/version.go
@@ -16,14 +16,12 @@ var (
 	GoVersion = runtime.Version()
 )
 
-var (
-	buildInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "build_info",
-			Help: "A metric with a constant '1' value labeled by version, revision, branch and goversion from which exporter_exporter was built.",
-		},
-		[]string{"version", "revision", "branch", "goversion"},
-	)
+var buildInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "build_info",
+		Help: "A metric with a constant '1' value labeled by version, revision, branch and goversion from which exporter_exporter was built.",
+	},
+	[]string{"version", "revision", "branch", "goversion"},
 )
 
 func init() {


### PR DESCRIPTION
Used to automaticly discover enabled modules on localhost
Will be used together with https://github.com/FortnoxAB/prometheus-net-discovery

The idea is to dynamicly discover modules based on what's running on the machine at the moment. So we don't have to have another automation software reconfigure exporter_exporter when exporters are added or removed on a VM. We deploy some software using kubernetes (with hostNetwork) and some with ansible. 

Now all those services can be automaticly discovered by exporter_exporter and exposed through the JSON api on port 9999 for `prometheus-net-discovery` to configure prometheus for scraping. 

Our expexp.yaml now looks like this:
```
discovery: 
  enabled: true
  exporters: 
    node:
      port: 9100
    minio:
      port: 9091
      path: "http://%s/minio/prometheus/metrics"
    elasticsearch:
      port: 9114
    haproxy:
      port: 9101
    mysql:
      port: 9104
    nginx:
      port: 9113
    redis:
      port: 9121
    memcached:
      port: 9150
    postfix:
      port: 9154
    postgres:
      port: 9187
    pgbouncer:
      port: 9188
    barman:
      port: 9189
    php-fpm:
      port: 9253
    kafka:
      port: 9308
    389ds:
      port: 9496
    imap-mailbox:
      port: 9893
    etcd:
      port: 2379
      path: "http://%s/metrics"

```

Then we have added https://github.com/FortnoxAB/prometheus-net-discovery/blob/master/main.go#L348
So we automaticly configure targets like this for discovered hosts. Then we make sure we also have a job named `node` (and all others in the list above) configured in prometheus. 

/etc/prometheus/file_sd/node.json
```
[
        {
                "targets": [
                        "10.0.0.104:9999"
                ],
                "labels": {
                        "__metrics_path__": "/proxy",
                        "__param_module": "node",
                        "host": "k8s-dev001-worker002.asdf.com",
                        "subnet": "10.0.0.0/24"
                }
        },
.....
```

We have been running this in production on 24 k8s clusters and about 500 VMs for 2 months. Has worked really well and removed alot of manual configuration when services are added. 

I also added some refactoring and optimizations on code, fixed some race conditions aswell as some autoformatting to make comments etc follow idiomatic go.