### PR TITLE
Add config dir note in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ files.  The module name is taken from the name of the file (minus the
 yml/yaml extension), and the configuration for that module goes in at the
 top level.
 
+Note that if you want to use *only* this configuration method and not the file-based 
+configuration (`-config.file` option), you must provide an empty string for the file
+option : `./exporter_exporter -config.file "" -config.dirs "/etc/exporter_exporter/"`
+
 ```
 ==> expexp.yaml <==
 modules: {}


### PR DESCRIPTION
When using only directory-based config, the exporter stops with an error:
```
$ ./exporter_exporter -log.level trace -config.dirs /etc/exporter_exporter/ --web.listen-address="0.0.0.0:8599"
ERRO[0000] open expexp.yaml: no such file or directory
```

If you provide an empty file or a file with an empty `modules` section, it crashes
```
$ cat test.yml 
modules:
$ ./exporter_exporter -config.file ./test.yml -config.dirs /etc/exporter_exporter/ --web.listen-address="0.0.0.0:8599"
panic: assignment to entry in nil map

goroutine 1 [running]:
main.setup(0x0, 0x0, 0x0)
        /home/tristan/src/exporter_exporter/main.go:174 +0xdce
main.main()
        /home/tristan/src/exporter_exporter/main.go:323 +0xd
$ ./exporter_exporter -log.level trace -config.file /dev/null -config.dirs /etc/exporter_exporter/ --web.listen-address="0.0.0.0:8599"
panic: assignment to entry in nil map

goroutine 1 [running]:
main.setup(0x0, 0x0, 0x0)
        /home/tristan/src/exporter_exporter/main.go:174 +0xdce
main.main()
        /home/tristan/src/exporter_exporter/main.go:323 +0xde
```

The other option is to set the default value of the config file to an empty string instead of "expexp.yaml" but that will break default configuration https://github.com/QubitProducts/exporter_exporter/blob/master/main.go#L45