### PR TITLE
Update build image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 AS build
+FROM golang:1.16-alpine AS build
 
 RUN mkdir /src
 WORKDIR /src


### PR DESCRIPTION
This patch replaces the build image in the Dockerfile
with the `-alpine` variant to fix issues with running
the binary inside alpine as run image.

Without this change the exporter-exporter docker
image is not usable. Running a container with it
exits immediately with the following error message:

```
standard_init_linux.go:228: exec user process caused: no such file or directory
```