### PR TITLE
allow disabling repsonse verification

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,9 +39,10 @@ type config struct {
 }
 
 type moduleConfig struct {
-	Method  string                 `yaml:"method"`
-	Timeout time.Duration          `yaml:"timeout"`
-	XXX     map[string]interface{} `yaml:",inline"`
+	Method            string                 `yaml:"method"`
+	Timeout           time.Duration          `yaml:"timeout"`
+	NoValidateMetrics bool                   `yaml:"no_validate_metrics"`
+	XXX               map[string]interface{} `yaml:",inline"`
 
 	Exec execConfig `yaml:"exec"`
 	HTTP httpConfig `yaml:"http"`


### PR DESCRIPTION
See also commit message.

Actually a key "validate_metrics" with a "true" default value would be better, but my go knowledge is too limited. So, I've introduced "no_validate_metrics"