### PR TITLE
feat: extended labels

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-  schedule:
-    - cron: '16 11 * * 1'
+  #schedule:
+  #  - cron: '16 11 * * 1'
 
 jobs:
   analyze:

--- a/expexp_extended_labels_example.yaml
+++ b/expexp_extended_labels_example.yaml
@@ -1,0 +1,10 @@
+defaultModule: snmp
+modules:
+  snmp:
+    method: http
+    http:
+      port: 9116
+      path: /snmp
+      label_extend: true
+      label_extend_path: ./extended_labels/interfaces.yaml
+      label_extend_target_url_identity: target

--- a/expexp_extended_labels_example.yaml
+++ b/expexp_extended_labels_example.yaml
@@ -5,6 +5,6 @@ modules:
     http:
       port: 9116
       path: /snmp
-      label_extend: true
-      label_extend_path: ./extended_labels/interfaces.yaml
-      label_extend_target_url_identity: target
+      extend_labels: true
+      extend_labels_path: ./extended_labels/interfaces.yaml
+      extend_labels_target_url_identity: target

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/aktau/github-release v0.10.0
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/github-release/github-release v0.10.0 h1:nJ3oEV2JrC0brYi6B8CsXumn/ORFeiAEOB2fwN9epOw=
 github.com/github-release/github-release v0.10.0/go.mod h1:CcaWgA5VoBGz94mOHYIXavqUA8kADNZxU+5/oDQxF6o=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -53,6 +55,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/http.go
+++ b/http.go
@@ -301,8 +301,8 @@ func matchMetricsName(name string, matchMetricsName *string) bool {
 }
 
 func getTargetMatch(request *http.Request, cfg moduleConfig) *ExtendedLabelTarget {
-	target := request.URL.Query().Get(*cfg.HTTP.LabelExtendTargetIdentity)
-	kalle := cfg.HTTP.LabelExtendConfig.ExtendedLabels[target]
+	target := request.URL.Query().Get(*cfg.HTTP.ExtendLabelsTargetURLIdentity)
+	kalle := cfg.HTTP.LabelExtendConfig.Targets[target]
 	return &kalle
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -31,7 +31,7 @@ func BenchmarkReverseProxyHandler(b *testing.B) {
 	modCfg := &moduleConfig{
 		Method:  "http",
 		Timeout: 5 * time.Second,
-		HTTP: httpConfig{
+		HTTP: &httpConfig{
 			Verify:  &verify,
 			Scheme:  URL.Scheme,
 			Address: URL.Hostname(),

--- a/watcher.go
+++ b/watcher.go
@@ -33,7 +33,10 @@ func watch(cfg *moduleConfig) {
 				log.Debug(fmt.Sprintf("Event: %v", event.Name))
 				if event.Op&fsnotify.Write == fsnotify.Write {
 					log.Info(fmt.Sprintf("Modified file: %v", event.Name))
-					labelConfig, _ := cfg.HTTP.getExtendedLabelConfig()
+					labelConfig, err := cfg.HTTP.getExtendedLabelConfig()
+					if err != nil {
+						log.Error("Error watcher: ", err)
+					}
 					cfg.HTTP.LabelExtendConfig = labelConfig
 				}
 			case err := <-watcher.Errors:
@@ -42,7 +45,7 @@ func watch(cfg *moduleConfig) {
 		}
 	}()
 
-	err = watcher.Add(*cfg.HTTP.LabelExtendPath)
+	err = watcher.Add(*cfg.HTTP.ExtendLabelsPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/watcher.go
+++ b/watcher.go
@@ -1,0 +1,49 @@
+// Copyright 2016 Qubit Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+)
+
+func watch(cfg *moduleConfig) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		for {
+			log.Debug("watcher loop")
+			select {
+			case event := <-watcher.Events:
+				log.Debug(fmt.Sprintf("Event: %v", event.Name))
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					log.Info(fmt.Sprintf("Modified file: %v", event.Name))
+					labelConfig, _ := cfg.HTTP.getExtendedLabelConfig()
+					cfg.HTTP.LabelExtendConfig = labelConfig
+				}
+			case err := <-watcher.Errors:
+				log.Error("Error watcher:", err)
+			}
+		}
+	}()
+
+	err = watcher.Add(*cfg.HTTP.LabelExtendPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Inserting labels on metrics based on label name and label value

This PR is maybe out of scope for what you think exporter_exporter is targeted for, but I have a use case where I need to insert additional labels based on existing labels, matching by the label name and label value. This use case is specific to the snmp_exporter, but should be applicable for any exporter that is configured as a proxy.

In this use case we need, for a specific target and interface(s), add additional labels. The source of this information would be a type of discovery, for example a source like a network management system. Just using Prometheus discovery will not be enough since we can only create discovery based labels on the target and not for specific "individuals" that are defined by a label name and label value, like an interface index.

I have called the the additional logic to the exporter_exporter "extended labels". In the expexp.yaml the following 3 additional parameters needs to be configured to achieve this. 

```yaml
defaultModule: snmp
modules:
  snmp:
    method: http
    http:
      port: 9116
      path: /snmp
      label_extend: true
      label_extend_target_url_identity: target
      label_extend_path: /tmp/interfaces.yaml
      
```

`label_extend` set to true just enable the feature for the module. The second , `label_extend_target_url_identity`, define what target the extended labels should be match against. For the snmp-exporter the url parameter `target`define the host that snmp should be executed against. The third, `label_extend_path`,  define the path to the extended labels configuration, typical created by some automation.

The configuration, defined by `label_extend_path` has the following format, using an example that is applicable, but not limited, to the snmp-exporter use case:

```yaml
extended_labels:
  foo.bar.org:
    labels:
    -
      label_key_name: "ifIndex"
      extended_labels:
        -
          metric_match: ifOperStatus
          match_label_key_values:
            "*":
          default_label_pairs:
            type: l2switch
        -
          metric_match: if(Admin|Oper)Status
          match_label_key_values:
            "370":
              label_pairs:
                 trunk: true
                 endpoint: 172.25.1.19:13
            "371":
              label_pairs:
                trunk: true
                endpoint: 172.25.1.13:45
    -
      label_key_name: "iftype"
      extended_labels:
        - match_label_key_values:
            "mpls":
              label_pairs:
                external: true
  abc.xyz.org:
    labels:
     .......
```

So `extended_labels`include a map of targets, in the above example a host name. The entry is matched against the value of the url query parameter defined by `label_extend_target_url_identity`. So if a metrics has a label named `ifIndex`, defined by `label_key_name`,  the logic will evaluate against what is configured in the `extended_labels`. First it will validate if this is only applicable to specific named metrics, for example `ifOperStatus`. The `metric_match` value is a regular expression and default to `.*` if not defined. The `match_label_key_values` define what label value to match against. In the first entry the match is done against all values, `*` of `ifIndex` and a label called `type` with value `l2switch` is added. In the second entry, both the metrics named  `ifOperStatus` and `ifAdminStatus` is matched, but labels, `trunk` and `endpoint`, are only added for metrics where `ifIndex` has the value of `370` or `371`. 

Most of the logic is in the function `getLabelExtendReverseProxyModifyResponseFunc` in the http.go file. This function is used instead of `getReverseProxyModifyResponseFunc` if `label_extend` is set to true.

I also added watcher.go that manage dynamic reload of the file defined by `label_extend_path`.

I have not updated README.md, but will if you think this PR is applicable for exporter_exporter.

I can fully understand if this functionality is something you find out of scope for the exporter_exporter. If this is the case I hope it would be okay if I create a separate repo for this with the credits to exporter_exporter and the additional code using the same license as exporter_exporter.

