### PR TITLE
Http module add to root ca

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ type httpConfig struct {
 	TLSKeyFile            *string                `yaml:"tls_key_file"`             // no default
 	TLSCACertFile         *string                `yaml:"tls_ca_cert_file"`         // no default
 	TLSRootCaFile         *string                `yaml:"tls_root_ca_file"`         // no default
+	TLSServerName         *string                `yaml:"server_name"`              // no default
 	Port                  int                    `yaml:"port"`                     // no default
 	Path                  string                 `yaml:"path"`                     // /metrics
 	Scheme                string                 `yaml:"scheme"`                   // http
@@ -214,6 +215,9 @@ func (c httpConfig) getTLSConfig() (*tls.Config, error) {
 		systemCAPool.AppendCertsFromPEM(caRootCert)
 
 		config.RootCAs = systemCAPool
+	}
+	if c.TLSServerName != nil {
+		config.ServerName = *c.TLSServerName
 	}
 	if c.TLSCertFile != nil && c.TLSKeyFile != nil {
 		cert, err := tls.LoadX509KeyPair(*c.TLSCertFile, *c.TLSKeyFile)


### PR DESCRIPTION
If the `http` module to which the `exporter_exporter` proxies is protected by a certificate authority, which is not part of the system root CA pool, connections will fail with

```
msg="Proxy error for module 'node': x509: certificate signed by unknown authority"
```

The changes in commit `7afa456` allow per http module inclusion of a Root CA to the Root CA pool that is being used by the httpProxy client.
The changes in commit `3b66f6d` allow per http module overwrite of the ServerName that is used to validate the SAN of the server tls certificate. In other words, if you have an exporter protected with a TLS certificate with SAN name `test.com`, but you want to connect to it by IP address, you can do the following:

```
modules:
  node:
    method: http
    http:
      scheme: https
      port: 9100
      address: 127.0.0.1
      server_name: test.com
```